### PR TITLE
Bailing out early if no error

### DIFF
--- a/src/Witness.sol
+++ b/src/Witness.sol
@@ -97,6 +97,9 @@ contract Witness is IWitness, OwnableRoles {
     /// @inheritdoc IWitness
     function verifyProof(Proof calldata proof) external view virtual {
         ProofError e = validateProof(proof, _rootInfo[proof.targetRoot].treeSize);
+        if (e == ProofError.NONE) {
+            return;
+        }
 
         if (e == ProofError.InvalidProofLeafIdxOutOfBounds) {
             revert InvalidProofLeafIdxOutOfBounds();


### PR DESCRIPTION
I *think* this is better? Because now in the "happy case" (which should be the majority) we won't check all those other `if`s?

Open to suggestion if I'm off-base! 😁 